### PR TITLE
machinetalk-protobuf: added name field to config

### DIFF
--- a/proto/status.proto
+++ b/proto/status.proto
@@ -205,6 +205,7 @@ message EmcStatusConfig {
     optional bool                       no_force_homing          = 34;
     optional string                     remote_path              = 35;
     optional EmcTimeUnitsType           time_units               = 36;
+    optional string                     name                     = 37;
 }
 
 message EmcStatusMotion {


### PR DESCRIPTION
Added name field for the machine name (EMC/MACHINE)
