### PR TITLE
for-proto: add no_create flag to Component submessage

### DIFF
--- a/proto/object.proto
+++ b/proto/object.proto
@@ -141,6 +141,9 @@ message Component {
 
     repeated Pin         pin            = 16;
     repeated Param       param          = 17;
+
+    // do not create the component on MT_HALRCOMP_BIND if the component does not exist
+    optional bool        no_create      = 18;
 }
 
 message Ring {


### PR DESCRIPTION
use case: do not accidentially create components on MT_HALRCOMP_BIND
if they do not exist
