### PR TITLE
status: adding per axis increments value to config message

### DIFF
--- a/proto/status.proto
+++ b/proto/status.proto
@@ -148,6 +148,7 @@ message EmcStatusConfigAxis {
     optional int32          home_sequence       = 9;
     optional double         max_acceleration    = 10;
     optional double         max_velocity        = 11;
+    optional string         increments          = 12;
 }
 
 message EmcProgramExtension {


### PR DESCRIPTION
Currently only one `increments` value for all axes could be used. This patch adds an additional increments field to each axis messages to support different jog increments for different axes.