### PR TITLE
Fix unicode problem in protoc-gen-depends

### DIFF
--- a/scripts/protoc-gen-depends
+++ b/scripts/protoc-gen-depends
@@ -21,8 +21,11 @@ from optparse import OptionParser
 import sys
 import os, string
 
+# Read all bytes (without text-encoding) from stdin to input_str
+input_str = sys.stdin.buffer.raw.readall()
+
 req = CodeGeneratorRequest()
-req.MergeFromString(''.join(stdin.readlines()))
+req.MergeFromString(input_str)
 
 optparser = OptionParser()
 optparser.add_option("-v","--vpath", dest="vpath", metavar="DIR", action="append", default=[], help="list of directories to search for proto files.")
@@ -81,4 +84,4 @@ def add_depends(fd):
 
 res.file.extend([add_depends(fileDescriptor) for fileDescriptor in req.proto_file])
 
-stdout.write(res.SerializeToString())
+stdout.buffer.write(res.SerializeToString())


### PR DESCRIPTION
When running make, I had the following error:
```
Traceback (most recent call last):
  File "scripts/protoc-gen-depends", line 25, in <module>
    req.MergeFromString(''.join(stdin.readlines()))
  File "/usr/lib/python3.4/codecs.py", line 319, in decode
    (result, consumed) = self._buffer_decode(data, self.errors, final)
UnicodeDecodeError: 'utf-8' codec can't decode byte 0xc6 in position 161: invalid continuation byte
--depends_out: protoc-gen-depends: Plugin failed with status code 1.
```

It was caused by stdin being read as a text-stream (default for sys.stdin). My machine is configured to use UTF-8 as text-encoding and in turn it seemed Python couldn't decode the stream as UTF-8.

This change uses sys.stdin.buffer, instead of sys.stdin, which should read bytes instead of encoded-text-strings.