### PR TITLE
OriginIndex: added ORIGIN_UNKNOWN field:

### DIFF
--- a/proto/types.proto
+++ b/proto/types.proto
@@ -650,6 +650,7 @@ enum ContainerType {
 }
 
 enum OriginIndex {
+    ORIGIN_UNKNOWN = 0;
     ORIGIN_G54 = 1;
     ORIGIN_G55 = 2;
     ORIGIN_G56 = 3;


### PR DESCRIPTION
occasionally emcstatus reports origins with the index 0 > to fix
problems with Protobuf enum value checking we add a new enum field with
the value 0