### PR TITLE
added types for command feedback

### DIFF
--- a/proto/types.proto
+++ b/proto/types.proto
@@ -636,6 +636,10 @@ enum ContainerType {
     MT_EMC_NML_TEXT = 12511;
     MT_EMC_NML_DISPLAY = 12512;
 
+    // EMC command
+    MT_EMCCMD_EXECUTED = 12520;
+    MT_EMCCMD_COMPLETED = 12521;
+
     // launcher pub-sub
     MT_LAUNCHER_FULL_UPDATE = 12600;
     MT_LAUNCHER_INCREMENTAL_UPDATE = 12601;


### PR DESCRIPTION
This patch adds two new types to be used a feedback to EMC command
requests. One indicates command execution and the other command
completion.