### PR TITLE
fix backwards compatibility with Python2

### DIFF
--- a/scripts/protoc-gen-depends
+++ b/scripts/protoc-gen-depends
@@ -21,8 +21,12 @@ from optparse import OptionParser
 import sys
 import os, string
 
-# Read all bytes (without text-encoding) from stdin to input_str
-input_str = sys.stdin.buffer.raw.readall()
+if sys.version_info >= (3, 0):
+    # Python 3 does handle encoding differently
+    # Read all bytes (without text-encoding) from stdin to input_str
+    input_str = sys.stdin.buffer.raw.readall()
+else:
+    input_str = sys.stdin.read()
 
 req = CodeGeneratorRequest()
 req.MergeFromString(input_str)
@@ -84,4 +88,9 @@ def add_depends(fd):
 
 res.file.extend([add_depends(fileDescriptor) for fileDescriptor in req.proto_file])
 
-stdout.buffer.write(res.SerializeToString())
+if sys.version_info >= (3, 0):
+    # With Python 3 we write to buffer
+    stdout.buffer.write(res.SerializeToString())
+else:
+    stdout.write(res.SerializeToString())
+


### PR DESCRIPTION
Python2 support was broken with https://github.com/machinekit/machinetalk-protobuf/pull/23
Encoding problems where a result of Python3 handling command line encoding differently than Python2.