### PR TITLE
use python from environment

### DIFF
--- a/scripts/protoc-gen-depends
+++ b/scripts/protoc-gen-depends
@@ -1,4 +1,4 @@
-#!/usr/bin/python
+#!/usr/bin/env python
 # protoc plugin to generate dependeny files
 #
 # the .d file format is rather project specific


### PR DESCRIPTION
This makes sure python is used by looking at `PATH`. Without this `scripts/protoc-gen-depends` might run with a different python version compared to the rest. This also helps when `/usr/bin/python` is non-existent (for virtualenv or NixOS).