### PR TITLE
generating single doc file with defined template

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -83,8 +83,6 @@ vpath %.proto  $(PROTODIR):$(GPBINCLUDE):$(DESCDIR)/compiler
 PROTO_PY_TARGETS := ${PROTO_SPECS:$(SRCDIR)/%.proto=$(PYGEN)/%_pb2.py}
 PROTO_PY_EXTRAS := $(PYGEN)/setup.py $(PYGEN)/machinetalk/__init__.py $(PYGEN)/machinetalk/protobuf/__init__.py
 
-PROTO_DOC_TARGETS=${PROTO_SPECS:$(SRCDIR)/%.proto=$(DOCGEN)/%.md}
-
 # generated C++ includes
 PROTO_CXX_INCS := ${PROTO_SPECS:$(SRCDIR)/%.proto=$(CXXGEN)/%.pb.h}
 
@@ -171,14 +169,14 @@ $(PYGEN)/%.py: python/%.py
 # see https://github.com/estan/protoc-gen-doc
 #
 # generate Markdown files from proto files
-$(DOCGEN)/%.md: $(SRCDIR)/%.proto
-	$(ECHO) "protoc create $@ from $<"
+docs_base: $(PROTODIR)/*.proto
+	$(ECHO) "protoc create machinetalk-protobuf.md from *.proto"
 	@mkdir -p $(DOCGEN)
 	$(Q)$(PROTOC) $(PROTOC_FLAGS) \
 	--proto_path=$(SRCDIR)/ \
 	--proto_path=$(GPBINCLUDE)/ \
-	--doc_out=markdown,$@:./ \
-	$<
+	--doc_out=scripts/markdown.mustache,$(DOCGEN)/machinetalk-protobuf.md:./ \
+	$(PROTODIR)/*.proto
 
 # ------------- ProtoBuf.js rules ------------
 #
@@ -215,7 +213,7 @@ all: $(GENERATED) $(PROTO_DEPS)
 ios_replace:
 	sh scripts/ios-replace.sh $(CXXGEN)
 
-docs: $(PROTO_DEPS) $(PROTO_DOC_TARGETS)
+docs: $(PROTO_DEPS) docs_base
 
 clean:
 	rm -rf build

--- a/scripts/markdown.mustache
+++ b/scripts/markdown.mustache
@@ -1,0 +1,56 @@
+# Protocol Documentation
+<a name="top"/>
+
+## Table of Contents
+{{#files}}
+* [{{file_name}}](#{{file_name}})
+ {{#file_messages}}
+ * [{{message_long_name}}](#{{message_full_name}})
+ {{/file_messages}}
+ {{#file_enums}}
+ * [{{enum_long_name}}](#{{enum_full_name}})
+ {{/file_enums}}
+{{/files}}
+* [Scalar Value Types](#scalar-value-types)
+
+{{#files}}
+<a name="{{file_name}}"/>
+<p align="right"><a href="#top">Top</a></p>
+
+## {{file_name}}
+
+{{#file_messages}}
+<a name="{{message_full_name}}"/>
+### {{message_long_name}}
+{{message_description}}
+
+| Field | Type | Label | Description |
+| ----- | ---- | ----- | ----------- |
+{{#message_fields}}
+| <a name="{{message_full_name}}.{{field_name}}"/> {{field_name}} | [{{field_long_type}}](#{{field_full_type}}) | {{field_label}} | {{#nobr}}{{field_description}}{{/nobr}} |
+{{/message_fields}}
+
+{{/file_messages}}
+
+{{#file_enums}}
+<a name="{{enum_full_name}}"/>
+### {{enum_long_name}}
+{{enum_description}}
+
+| Name | Number | Description |
+| ---- | ------ | ----------- |
+{{#enum_values}}
+| {{value_name}} | {{value_number}} | {{#nobr}}{{value_description}}{{/nobr}} |
+{{/enum_values}}
+
+{{/file_enums}}
+{{/files}}
+
+<a name="scalar-value-types"/>
+## Scalar Value Types
+
+| .proto Type | Notes | C++ Type | Java Type | Python Type |
+| ----------- | ----- | -------- | --------- | ----------- |
+{{#scalar_value_types}}
+| <a name="{{scalar_value_proto_type}}"/> {{scalar_value_proto_type}} | {{scalar_value_notes}} | {{scalar_value_cpp_type}} | {{scalar_value_java_type}} | {{scalar_value_python_type}} |
+{{/scalar_value_types}}


### PR DESCRIPTION
Creates only a single doc file that is far better search-able and may be used a references for protocol documentation.