### PR TITLE
Preparation for Machinetalk generic

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -26,7 +26,8 @@ ECHO := @echo
 
 DESTDIR := /usr/local
 # all protobuf definitions live here
-NAMESPACEDIR := machinetalk/protobuf
+PROJECT := machinetalk
+NAMESPACEDIR := $(PROJECT)/protobuf
 SRCDIR := src
 SRCDIRINV := $(shell realpath --relative-to=$(SRCDIR) .)
 PROTODIR := $(SRCDIR)/$(NAMESPACEDIR)
@@ -70,9 +71,9 @@ OBJDIR := $(BUILDDIR)/objects
 # see note on PBDEP_OPT below
 vpath %.proto  $(PROTODIR):$(GPBINCLUDE):$(DESCDIR)/compiler
 
-# machinetalk/proto/*.proto derived Python bindings
+# $(PROJECT)/proto/*.proto derived Python bindings
 PROTO_PY_TARGETS := ${PROTO_SPECS:$(SRCDIR)/%.proto=$(PYGEN)/%_pb2.py}
-PROTO_PY_EXTRAS := $(PYGEN)/setup.py $(PYGEN)/machinetalk/__init__.py $(PYGEN)/machinetalk/protobuf/__init__.py
+PROTO_PY_EXTRAS := $(PYGEN)/setup.py $(PYGEN)/$(PROJECT)/__init__.py $(PYGEN)/$(PROJECT)/protobuf/__init__.py
 
 # generated C++ includes
 PROTO_CXX_INCS := ${PROTO_SPECS:$(SRCDIR)/%.proto=$(CXXGEN)/%.pb.h}
@@ -81,7 +82,7 @@ PROTO_CXX_INCS := ${PROTO_SPECS:$(SRCDIR)/%.proto=$(CXXGEN)/%.pb.h}
 PROTO_CXX_SRCS  :=  ${PROTO_SPECS:$(SRCDIR)/%.proto=$(CXXGEN)/%.pb.cc}
 
 # generated doc file
-DOC_TARGET := $(DOCGEN)/machinetalk-protobuf.$(DOCEXT)
+DOC_TARGET := $(DOCGEN)/$(PROJECT)-protobuf.$(DOCEXT)
 
 # ---- generate dependcy files for .proto files
 #

--- a/python/.gitignore
+++ b/python/.gitignore
@@ -1,0 +1,1 @@
+machinetalk

--- a/python/machinetalk/__init__.py
+++ b/python/machinetalk/__init__.py
@@ -1,1 +1,0 @@
-__import__('pkg_resources').declare_namespace(__name__)

--- a/python/machinetalk/protobuf/__init__.py
+++ b/python/machinetalk/protobuf/__init__.py
@@ -1,1 +1,0 @@
-__import__('pkg_resources').declare_namespace(__name__)

--- a/python/setup.py
+++ b/python/setup.py
@@ -2,13 +2,33 @@
 
 from distutils.core import setup
 
-#! /usr/bin/env python
-#
 # See README for usage instructions.
 import glob
 import os
 import subprocess
 import sys
+
+PROJECT = 'machinetalk'
+PROJECT_NAME = 'machinetalk-protobuf'
+PROJECT_URL = 'https://github.com/machinekit/machinetalk-protobuf'
+FILES = [
+    'canon.proto',
+    'config.proto',
+    'emcclass.proto',
+    'log.proto',
+    'message.proto',
+    'motcmds.proto',
+    'nanopb.proto',
+    'object.proto',
+    'preview.proto',
+    'rtapi_message.proto',
+    'rtapicommand.proto',
+    'status.proto',
+    'task.proto',
+    'test.proto',
+    'types.proto',
+    'value.proto'
+    ]
 
 # We must use setuptools, not distutils, because we need to use the
 # namespace_packages option for the "google" package.
@@ -97,33 +117,20 @@ class clean(_clean):
 
 class build_py(_build_py):
   def run(self):
+    source_path = '../src/%s/protobuf/' % PROJECT
     # Generate necessary .proto file if it doesn't exist.
-    generate_proto("../src/machinetalk/protobuf/canon.proto")
-    generate_proto("../src/machinetalk/protobuf/config.proto")
-    generate_proto("../src/machinetalk/protobuf/emcclass.proto")
-    generate_proto("../src/machinetalk/protobuf/log.proto")
-    generate_proto("../src/machinetalk/protobuf/message.proto")
-    generate_proto("../src/machinetalk/protobuf/motcmds.proto")
-    generate_proto("../src/machinetalk/protobuf/nanopb.proto")
-    generate_proto("../src/machinetalk/protobuf/object.proto")
-    generate_proto("../src/machinetalk/protobuf/preview.proto")
-    generate_proto("../src/machinetalk/protobuf/rtapi_message.proto")
-    generate_proto("../src/machinetalk/protobuf/rtapicommand.proto")
-    generate_proto("../src/machinetalk/protobuf/status.proto")
-    generate_proto("../src/machinetalk/protobuf/task.proto")
-    generate_proto("../src/machinetalk/protobuf/test.proto")
-    generate_proto("../src/machinetalk/protobuf/types.proto")
-    generate_proto("../src/machinetalk/protobuf/value.proto")
+    for file in FILES:
+      generate_proto(source_path + file)
 
     # _build_py is an old-style class, so super() doesn't work.
     _build_py.run(self)
 
 if __name__ == '__main__':
-      setup(name="machinetalk_protobuf",
+      setup(name=PROJECT_NAME,
             version="1.0",
-            description="Protobuf Python modules for Machinetalk",
-            url="https://github.com/machinekit/machinetalk-protobuf",
-            namespace_packages=['machinetalk'],
+            description="Protobuf Python modules for %s" % PROJECT,
+            url=PROJECT_URL,
+            namespace_packages=[PROJECT],
             packages=find_packages(),
             install_requires=['setuptools'],
             cmdclass={

--- a/python/setup.py
+++ b/python/setup.py
@@ -3,32 +3,13 @@
 from distutils.core import setup
 
 # See README for usage instructions.
-import glob
 import os
 import subprocess
 import sys
 
 PROJECT = 'machinetalk'
-PROJECT_NAME = 'machinetalk-protobuf'
 PROJECT_URL = 'https://github.com/machinekit/machinetalk-protobuf'
-FILES = [
-    'canon.proto',
-    'config.proto',
-    'emcclass.proto',
-    'log.proto',
-    'message.proto',
-    'motcmds.proto',
-    'nanopb.proto',
-    'object.proto',
-    'preview.proto',
-    'rtapi_message.proto',
-    'rtapicommand.proto',
-    'status.proto',
-    'task.proto',
-    'test.proto',
-    'types.proto',
-    'value.proto'
-    ]
+PROJECT_NAME = '%s-protobuf' % PROJECT
 
 # We must use setuptools, not distutils, because we need to use the
 # namespace_packages option for the "google" package.
@@ -119,8 +100,10 @@ class build_py(_build_py):
   def run(self):
     source_path = '../src/%s/protobuf/' % PROJECT
     # Generate necessary .proto file if it doesn't exist.
-    for file in FILES:
-      generate_proto(source_path + file)
+    for entry in os.listdir(source_path):
+      filepath = os.path.join(source_path, entry)
+      if os.path.isfile(filepath) and filepath.endswith('.proto'):
+          generate_proto(filepath)
 
     # _build_py is an old-style class, so super() doesn't work.
     _build_py.run(self)

--- a/python/setup.py
+++ b/python/setup.py
@@ -6,6 +6,7 @@ from distutils.core import setup
 import os
 import subprocess
 import sys
+import shutil
 
 PROJECT = 'machinetalk'
 PROJECT_URL = 'https://github.com/machinekit/machinetalk-protobuf'
@@ -84,8 +85,21 @@ def generate_proto(source, require = True):
     if subprocess.call(protoc_command) != 0:
       sys.exit(-1)
 
+def create_init(path):
+  if not os.path.exists(path):
+    os.mkdir(path)
+
+  initfile = os.path.join(path, '__init__.py')
+  if not os.path.exists(initfile):
+    content = "__import__('pkg_resources').declare_namespace(__name__)\n"
+    with open(initfile, 'w') as f:
+      f.write(content)
+
 class clean(_clean):
   def run(self):
+    # delete _init_ files
+    shutil.rmtree(PROJECT)
+
     # Delete generated files in the code tree.
     for (dirpath, dirnames, filenames) in os.walk("."):
       for filename in filenames:
@@ -99,6 +113,7 @@ class clean(_clean):
 class build_py(_build_py):
   def run(self):
     source_path = '../src/%s/protobuf/' % PROJECT
+
     # Generate necessary .proto file if it doesn't exist.
     for entry in os.listdir(source_path):
       filepath = os.path.join(source_path, entry)
@@ -109,6 +124,10 @@ class build_py(_build_py):
     _build_py.run(self)
 
 if __name__ == '__main__':
+      # create __init__ files
+      create_init(PROJECT)
+      create_init(PROJECT + '/protobuf')
+      # start the setup
       setup(name=PROJECT_NAME,
             version="1.0",
             description="Protobuf Python modules for %s" % PROJECT,

--- a/src/machinetalk/protobuf/canon.proto
+++ b/src/machinetalk/protobuf/canon.proto
@@ -7,7 +7,7 @@ import "machinetalk/protobuf/types.proto";
 import "machinetalk/protobuf/emcclass.proto";
 import "machinetalk/protobuf/motcmds.proto";
 
-package pb;
+package machinetalk;
 
 // communicated by message type only since no params:
 // Emc_Start_Change

--- a/src/machinetalk/protobuf/config.proto
+++ b/src/machinetalk/protobuf/config.proto
@@ -3,7 +3,7 @@ import "machinetalk/protobuf/nanopb.proto";
 // see README.msgid
 // msgid base: 200
 
-package pb;
+package machinetalk;
 
 enum ApplicationType {
     QT5_QML    = 1;

--- a/src/machinetalk/protobuf/emcclass.proto
+++ b/src/machinetalk/protobuf/emcclass.proto
@@ -3,7 +3,7 @@ import "machinetalk/protobuf/nanopb.proto";
 // see README.msgid
 // msgid base: 300
 
-package pb;
+package machinetalk;
 
 // this encoding method of encoding supports NULL values
 // using code needs to inspect the has_<name> property

--- a/src/machinetalk/protobuf/firmware.proto
+++ b/src/machinetalk/protobuf/firmware.proto
@@ -18,7 +18,7 @@ import "machinetalk/protobuf/nanopb.proto";
 // see README.msgid
 // msgid base: 380
 
-package pb;
+package machinetalk;
 
 /// describes a connector
 message Connector {

--- a/src/machinetalk/protobuf/log.proto
+++ b/src/machinetalk/protobuf/log.proto
@@ -1,4 +1,4 @@
-package pb;
+package machinetalk;
 // see README.msgid
 // msgid base: 400
 

--- a/src/machinetalk/protobuf/message.proto
+++ b/src/machinetalk/protobuf/message.proto
@@ -4,7 +4,7 @@
 // see README.msgid
 // msgid base: 500
 
-package pb;
+package machinetalk;
 
 
 import "machinetalk/protobuf/nanopb.proto";

--- a/src/machinetalk/protobuf/motcmds.proto
+++ b/src/machinetalk/protobuf/motcmds.proto
@@ -1,4 +1,4 @@
-package pb;
+package machinetalk;
 
 // see README.msgid
 // msgid base: 600

--- a/src/machinetalk/protobuf/object.proto
+++ b/src/machinetalk/protobuf/object.proto
@@ -7,7 +7,7 @@
 import "machinetalk/protobuf/nanopb.proto";
 import "machinetalk/protobuf/types.proto";
 
-package pb;
+package machinetalk;
 
 // describes a RTAPI/HAL/LinuxCNC instance
 message Instance {

--- a/src/machinetalk/protobuf/preview.proto
+++ b/src/machinetalk/protobuf/preview.proto
@@ -1,4 +1,4 @@
-package pb;
+package machinetalk;
 
 // see README.msgid
 // msgid base: 800

--- a/src/machinetalk/protobuf/rtapi_message.proto
+++ b/src/machinetalk/protobuf/rtapi_message.proto
@@ -4,7 +4,7 @@ import "machinetalk/protobuf/value.proto";
 // see README.msgid
 // msgid base: 1000
 
-package pb;
+package machinetalk;
 
 message RTAPI_Message {
 

--- a/src/machinetalk/protobuf/rtapicommand.proto
+++ b/src/machinetalk/protobuf/rtapicommand.proto
@@ -2,7 +2,7 @@ import "machinetalk/protobuf/nanopb.proto";
 // see README.msgid
 // msgid base: 900
 
-package pb;
+package machinetalk;
 
 message RTAPICommand {
 

--- a/src/machinetalk/protobuf/status.proto
+++ b/src/machinetalk/protobuf/status.proto
@@ -7,7 +7,7 @@ import "machinetalk/protobuf/motcmds.proto";
 // see README.msgid
 // msgid base: 1100
 
-package pb;
+package machinetalk;
 
 /**
  *  Types for EMC task execution state.

--- a/src/machinetalk/protobuf/task.proto
+++ b/src/machinetalk/protobuf/task.proto
@@ -41,7 +41,7 @@ import "machinetalk/protobuf/nanopb.proto";
 // see README.msgid
 // msgid base: 1200
 
-package pb;
+package machinetalk;
 
 
 message TaskPlanExecute {

--- a/src/machinetalk/protobuf/test.proto
+++ b/src/machinetalk/protobuf/test.proto
@@ -3,7 +3,7 @@
 import "machinetalk/protobuf/emcclass.proto";
 import "machinetalk/protobuf/nanopb.proto";
 
-package pb;
+package machinetalk;
 
 // see README.msgid
 // msgid base: 1300

--- a/src/machinetalk/protobuf/types.proto
+++ b/src/machinetalk/protobuf/types.proto
@@ -4,7 +4,7 @@ import "machinetalk/protobuf/nanopb.proto";
 // see README.msgid
 // msgid base: 1400
 
-package pb;
+package machinetalk;
 
 enum ValueType {
     //  the following tags correspond to hal.h: hal_type_t;

--- a/src/machinetalk/protobuf/value.proto
+++ b/src/machinetalk/protobuf/value.proto
@@ -6,7 +6,7 @@ import "machinetalk/protobuf/types.proto";
 // see README.msgid
 // msgid base: 1500
 
-package pb;
+package machinetalk;
 
 
 // a value for 'passing around'.


### PR DESCRIPTION
This patch prepares the `machinetalk-protobuf` repository for general usage.

The idea is to use to make Machinetalk usable for other projects besides Machinekit. For this purpose, this patch introduces `PROJECT` variables so the project namespace is easier to change.