### PR TITLE
Amend asciidoc.mustache

### DIFF
--- a/scripts/asciidoc.mustache
+++ b/scripts/asciidoc.mustache
@@ -1,3 +1,7 @@
+---
+layout: docs
+---
+
 = Machinetalk Protobuf Documentation
 :toc:
 


### PR DESCRIPTION
Match the pre-header of asciidoc.mustache to that used in `machinekit-docs/scripts/machinekit.mustache`.
Jekyll is currently ignoring the protobuf.asciidoc generated from this repo when rendering the website.