### PR TITLE
config: add support importance and set command

### DIFF
--- a/src/machinetalk/protobuf/config.proto
+++ b/src/machinetalk/protobuf/config.proto
@@ -76,4 +76,5 @@ message Launcher {
     optional int32        returncode     = 11; // return code of the command
     optional string       workdir        = 12; // working dir of the command
     optional uint32       priority       = 13; // priority for sorting, smaller means lower priority
+    optional uint32       importance     = 14; // importance set by the user, smaller means less important
 }

--- a/src/machinetalk/protobuf/types.proto
+++ b/src/machinetalk/protobuf/types.proto
@@ -696,6 +696,7 @@ enum ContainerType {
     MT_LAUNCHER_WRITE_STDIN = 12613;
     MT_LAUNCHER_CALL = 12614;
     MT_LAUNCHER_SHUTDOWN = 12615;
+    MT_LAUNCHER_SET = 12616;
 }
 
 enum OriginIndex {


### PR DESCRIPTION
This PR adds a new field to the launcher service describing the importance of a config. The field is intended to be used by the user to mark configs as important (favorites).