### PR TITLE
Add File Service support

### DIFF
--- a/src/machinetalk/protobuf/config.proto
+++ b/src/machinetalk/protobuf/config.proto
@@ -21,9 +21,12 @@ message File {
 
     option (nanopb_msgopt).msgid = 200; // see README.msgid
 
-    required string       name          = 1; // flat for now
-    required FileContent  encoding      = 2;
-    optional bytes        blob          = 3;
+    required string       name          = 1;                   // file name or path, flat for now
+    required FileContent  encoding      = 2;                   // file encoding
+    optional bytes        blob          = 3 [default = ""];    // file data
+    optional uint32       size          = 4 [default = 0];     // file size
+    optional bool         is_dir        = 5 [default = false]; // indicates if file is actually a directo
+    optional uint64       last_modified = 6 [default = 0];     // timestamp of last modification
 }
 
 message Application {
@@ -77,4 +80,9 @@ message Launcher {
     optional string       workdir        = 12; // working dir of the command
     optional uint32       priority       = 13; // priority for sorting, smaller means lower priority
     optional uint32       importance     = 14; // importance set by the user, smaller means less important
+}
+
+// message for file service
+message FileServiceData {
+    repeated File  files           = 1; // list of files
 }

--- a/src/machinetalk/protobuf/config.proto
+++ b/src/machinetalk/protobuf/config.proto
@@ -21,12 +21,12 @@ message File {
 
     option (nanopb_msgopt).msgid = 200; // see README.msgid
 
-    required string       name          = 1;                   // file name or path, flat for now
-    required FileContent  encoding      = 2;                   // file encoding
-    optional bytes        blob          = 3 [default = ""];    // file data
-    optional uint32       size          = 4 [default = 0];     // file size
-    optional bool         is_dir        = 5 [default = false]; // indicates if file is actually a directo
-    optional uint64       last_modified = 6 [default = 0];     // timestamp of last modification
+    required string       name          = 1;                       // file name or path, flat for now
+    optional FileContent  encoding      = 2 [default = CLEARTEXT]; // file encoding
+    optional bytes        blob          = 3 [default = ""];        // file data
+    optional uint32       size          = 4 [default = 0];         // file size
+    optional bool         is_dir        = 5 [default = false];     // indicates if file is actually a directo
+    optional uint64       last_modified = 6 [default = 0];         // timestamp of last modification
 }
 
 message Application {

--- a/src/machinetalk/protobuf/message.proto
+++ b/src/machinetalk/protobuf/message.proto
@@ -155,6 +155,11 @@ message Container {
     repeated Launcher launcher = 130 [(nanopb).type = FT_IGNORE];
     optional int32    index    = 131 [(nanopb).type = FT_IGNORE];
 
+    // the file service data is used by file service related messages
+    // MT_FILE_*
+    optional FileServiceData file_service_data = 135 [(nanopb).type = FT_IGNORE];
+    
+
     // // miscellanous typed objects
     // optional string        ascii          = 140;
     // optional bytes         unicode        = 141;

--- a/src/machinetalk/protobuf/types.proto
+++ b/src/machinetalk/protobuf/types.proto
@@ -387,6 +387,9 @@ enum ContainerType {
     MT_FULL_UPDATE = 370;
     MT_INCREMENTAL_UPDATE = 371;
 
+    // generic cmd reply
+    MT_CMD_COMPLETE = 380;
+
     // task/client comms
     MT_TASK_REPLY     = 400;
     MT_TICKET_UPDATE  = 401;
@@ -697,6 +700,15 @@ enum ContainerType {
     MT_LAUNCHER_CALL = 12614;
     MT_LAUNCHER_SHUTDOWN = 12615;
     MT_LAUNCHER_SET = 12616;
+
+    // remote file
+    MT_FILE_GET     = 12700;
+    MT_FILE_PUT     = 12701;
+    MT_FILE_LS      = 12702;
+    MT_FILE_MKDIR   = 12703;
+    MT_FILE_DELETE  = 12704;
+    MT_FILE_DATA    = 12705;
+    MT_FILE_LISTING = 12706;
 }
 
 enum OriginIndex {


### PR DESCRIPTION
This PR adds support for a new Machinetalk-based file service. This allows FTP-alike upload/download of files without requiring and FTP implementation on the host machine.