### PR TITLE
EmcStatusMotion: add support for extended G54.1 origins

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -15,7 +15,7 @@ from codecs import open
 PROJECT = "machinetalk"
 PROJECT_NAME = "%s-protobuf" % PROJECT
 DESCRIPTION = "Protobuf Python modules for %s" % PROJECT
-VERSION = "1.2.0"
+VERSION = "1.2.1"
 AUTHOR = "Alexander Roessler"
 AUTHOR_EMAIL = "alex@machinekoder.com"
 PROJECT_URL = "https://github.com/machinekit/%s" % PROJECT_NAME

--- a/src/machinetalk/protobuf/status.proto
+++ b/src/machinetalk/protobuf/status.proto
@@ -477,6 +477,7 @@ message EmcStatusMotion {
     optional double                 rapidrate               = 50; /// Current rapid override.
     repeated EmcStatusMotionJoint   joint                   = 51; /// Per joint motion values.
     repeated EmcStatusMotionSpindle spindle                 = 52; /// Per spindle motion values.
+    optional int32                  g5x_index_extended      = 53; /// Currently active coordinate system, extended index.
 }
 
 /**

--- a/src/machinetalk/protobuf/types.proto
+++ b/src/machinetalk/protobuf/types.proto
@@ -722,6 +722,7 @@ enum OriginIndex {
     ORIGIN_G59_1 = 7;
     ORIGIN_G59_2 = 8;
     ORIGIN_G59_3 = 9;
+    ORIGIN_G54_1 = 10; /// extended origin
 }
 
 


### PR DESCRIPTION
This PR adds a new field to the EmcStatusMotion message to support G54.1 extended work offsets.